### PR TITLE
make express optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Object validation with proper flow types and more.
 
 ```javascript
 import { arrayOf, string, number, object, instanceOf, Type, Vobject, asyncArrayOf, tuple, takes, match } from 'flow-validator';
+import { express } from 'flow-validator/express';
 
 // { name: string, age: ?number, toys: Array<string> }
 const Person = object({ name: string, age: number.optional(), toys: arrayOf(string) });

--- a/src/express.js
+++ b/src/express.js
@@ -1,0 +1,2 @@
+export { asyncExpress } from './async/asyncExpress';
+export { express } from './sync/express';

--- a/src/index.js
+++ b/src/index.js
@@ -42,5 +42,3 @@ export { asyncVobject } from './async/asyncVobject';
 export { asyncObjectExact } from './async/asyncObjectExact';
 export { asyncVobjectExact } from './async/asyncVobjectExact';
 export { match } from './sync/match';
-export { asyncExpress } from './async/asyncExpress';
-export { express } from './sync/express';

--- a/test/readme.spec.js
+++ b/test/readme.spec.js
@@ -2,7 +2,8 @@
 /* eslint-env mocha, browser */
 /* eslint-disable no-unused-vars */
 
-import { arrayOf, string, number, object, instanceOf, Type, Vobject, asyncArrayOf, tuple, takes, match, express } from '../src';
+import { arrayOf, string, number, object, instanceOf, Type, Vobject, asyncArrayOf, tuple, takes, match } from '../src';
+import { express } from '../src/express';
 
 describe('readme code', () => {
   it('works', () => {


### PR DESCRIPTION
This PR makes `express` an optional dependency to allow using `flow-validator` in projects that don't depend on `express`.